### PR TITLE
Generic bug

### DIFF
--- a/src/main/java/com/fleetpin/graphql/builder/AuthorizerSchema.java
+++ b/src/main/java/com/fleetpin/graphql/builder/AuthorizerSchema.java
@@ -57,6 +57,9 @@ public class AuthorizerSchema {
 				if(basePackages.contains(name)) {
 					return null;
 				}
+				if(name.indexOf('.') == -1) {
+					throw new RuntimeException("Referencing class outside base package " + type);
+				}
 				name = name.substring(0, name.lastIndexOf('.'));
 			}else {
 				return auth;

--- a/src/main/java/com/fleetpin/graphql/builder/EntityProcessor.java
+++ b/src/main/java/com/fleetpin/graphql/builder/EntityProcessor.java
@@ -54,7 +54,10 @@ public class EntityProcessor {
 		throw new RuntimeException("extraction failure for " + type.getClass());
 	}
 
-	private void addType(Class<?> type, Type genericType, boolean input) {
+	private void addType(Class<?> type, Type genericType) {
+		if(genericType == null) {
+			genericType = type;
+		}
 		try {
 			if(type.isAnnotationPresent(Scalar.class)) {
 				GraphQLScalarType.Builder scalarType = GraphQLScalarType.newScalar();
@@ -195,8 +198,19 @@ public class EntityProcessor {
 					if(parent.isAnnotationPresent(Entity.class)) {
 						String interfaceName = process(parent, type.getGenericSuperclass());
 						graphType.withInterface(GraphQLTypeReference.typeRef(interfaceName));
+						
+						if(!parent.equals(type.getGenericSuperclass())) {
+							interfaceName = process(parent, parent);
+							graphType.withInterface(GraphQLTypeReference.typeRef(interfaceName));
+						}
+						
 					}
 					parent = parent.getSuperclass();
+				}
+				
+				if(!type.equals(genericType)) {
+					String interfaceName = process(type, type);
+					graphType.withInterface(GraphQLTypeReference.typeRef(interfaceName));
 				}
 
 				if(schemaType == SchemaOption.BOTH || schemaType == SchemaOption.TYPE) {
@@ -282,8 +296,6 @@ public class EntityProcessor {
 					
 				}	
 			}
-			
-			System.out.println(genericType);
 		}
 		
 		return name;
@@ -292,7 +304,7 @@ public class EntityProcessor {
 	public String process(Class<?> type, Type genericType) {
 		String name = getName(type, genericType);
 				if(name != null && !this.additionalTypes.containsKey(name)) {
-			addType(type, genericType, false);
+			addType(type, genericType);
 		}
 		return name;
 	}
@@ -326,8 +338,6 @@ public class EntityProcessor {
 					
 				}	
 			}
-			
-			System.out.println(name);
 		}
 		
 		return name;
@@ -337,7 +347,7 @@ public class EntityProcessor {
 	public String processInput(Class<?> type, Type genericType) {
 		String name = getNameInput(type, genericType);
 		if(name != null && !this.additionalTypes.containsKey(name)) {
-			addType(type, genericType, true);
+			addType(type, genericType);
 		}
 		return name;
 	}

--- a/src/main/java/com/fleetpin/graphql/builder/EntityProcessor.java
+++ b/src/main/java/com/fleetpin/graphql/builder/EntityProcessor.java
@@ -303,7 +303,8 @@ public class EntityProcessor {
 
 	public String process(Class<?> type, Type genericType) {
 		String name = getName(type, genericType);
-				if(name != null && !this.additionalTypes.containsKey(name)) {
+		if(name != null && !this.additionalTypes.containsKey(name)) {
+			this.additionalTypes.put(name, null); // so we don't go around in circles if depend on self
 			addType(type, genericType);
 		}
 		return name;
@@ -347,6 +348,7 @@ public class EntityProcessor {
 	public String processInput(Class<?> type, Type genericType) {
 		String name = getNameInput(type, genericType);
 		if(name != null && !this.additionalTypes.containsKey(name)) {
+			this.additionalTypes.put(name, null); // so we don't go around in circles if depend on self
 			addType(type, genericType);
 		}
 		return name;

--- a/src/main/java/com/fleetpin/graphql/builder/EntityProcessor.java
+++ b/src/main/java/com/fleetpin/graphql/builder/EntityProcessor.java
@@ -1,0 +1,345 @@
+package com.fleetpin.graphql.builder;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Map;
+
+import com.fleetpin.graphql.builder.annotations.Entity;
+import com.fleetpin.graphql.builder.annotations.GraphQLIgnore;
+import com.fleetpin.graphql.builder.annotations.InputIgnore;
+import com.fleetpin.graphql.builder.annotations.Scalar;
+import com.fleetpin.graphql.builder.annotations.SchemaOption;
+
+import graphql.schema.idl.TypeRuntimeWiring;
+import graphql.Scalars;
+import graphql.schema.Coercing;
+import graphql.schema.DataFetcher;
+import graphql.schema.FieldCoordinates;
+import graphql.schema.GraphQLCodeRegistry;
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInputObjectField;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLObjectType.Builder;
+import graphql.schema.GraphQLScalarType;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLTypeReference;
+
+public class EntityProcessor {
+
+	private final Map<String, GraphQLType> additionalTypes;
+	private final GraphQLCodeRegistry.Builder codeRegistry;
+	private final DirectivesSchema directives;
+
+
+	public EntityProcessor(Map<String, GraphQLType> additionalTypes, GraphQLCodeRegistry.Builder codeRegistry, DirectivesSchema diretives) {
+		this.additionalTypes = additionalTypes;
+		this.codeRegistry = codeRegistry;
+		this.directives = diretives;
+	}
+	
+	
+	public static Class<?> extraOptionalType(Type type) {
+		if(type instanceof Class) {
+			return (Class<?>) type;
+		}else if(type instanceof ParameterizedType){
+			return extraOptionalType(((ParameterizedType) type).getActualTypeArguments()[0]);
+		}
+		throw new RuntimeException("extraction failure for " + type.getClass());
+	}
+
+	private void addType(Class<?> type, Type genericType, boolean input) {
+		try {
+			if(type.isAnnotationPresent(Scalar.class)) {
+				GraphQLScalarType.Builder scalarType = GraphQLScalarType.newScalar();
+				String typeName = getName(type, genericType);
+				scalarType.name(typeName);
+				Class<? extends Coercing> coerecing = type.getAnnotation(Scalar.class).value();
+				scalarType.coercing(coerecing.getDeclaredConstructor().newInstance());
+				var built = scalarType.build();
+				if(additionalTypes.put(built.getName(), built) != null) {
+					throw new RuntimeException(built.getName() + "defined more than once");
+				}
+			}
+			
+			if(type.isAnnotationPresent(Entity.class)) {
+				//special handling
+				if(type.isEnum()) {
+					graphql.schema.GraphQLEnumType.Builder enumType = GraphQLEnumType.newEnum();
+					String typeName = getName(type, genericType);
+					enumType.name(typeName);
+
+					Object[] enums = type.getEnumConstants();
+					for(Object e: enums) {
+						Enum a = (Enum) e;
+						if(type.getDeclaredField(e.toString()).isAnnotationPresent(GraphQLIgnore.class)) {
+							continue;
+						}
+						enumType.value(a.name(), a);
+					}
+					GraphQLEnumType built = enumType.build();
+					if(additionalTypes.put(built.getName(), built) != null) {
+						throw new RuntimeException(built.getName() + "defined more than once");
+					}
+					return;
+				}
+
+				SchemaOption schemaType = SchemaOption.BOTH;
+				Entity graphTypeAnnotation = type.getAnnotation(Entity.class);
+				if(graphTypeAnnotation != null) {
+					schemaType = graphTypeAnnotation.value();
+				}
+
+				Builder graphType = GraphQLObjectType.newObject();
+				String typeName = getName(type, genericType);
+				graphType.name(typeName);
+
+
+				GraphQLInterfaceType.Builder interfaceBuilder = GraphQLInterfaceType.newInterface();
+				interfaceBuilder.name(typeName);
+
+				GraphQLInputObjectType.Builder graphInputType = GraphQLInputObjectType.newInputObject();
+				if(schemaType == SchemaOption.INPUT) {
+					graphInputType.name(typeName);
+				}else {
+					graphInputType.name(typeName + "Input");
+				}
+
+				{
+					GraphQLInputObjectField.Builder field = GraphQLInputObjectField.newInputObjectField();
+					field.name("__typename");
+					field.type(Scalars.GraphQLString);
+					graphInputType.field(field);
+				}
+
+
+				TypeRuntimeWiring.Builder runtime = new TypeRuntimeWiring.Builder();
+				runtime.typeName(typeName);
+				for(Method method: type.getMethods()) {
+					try {
+						if(method.isSynthetic()) {
+							continue;
+						}
+						if(method.getDeclaringClass().equals(Object.class)) {
+							continue;
+						}
+						if(method.isAnnotationPresent(GraphQLIgnore.class)) {
+							continue;
+						}
+						//will also be on implementing class
+						if(Modifier.isAbstract(method.getModifiers()) || method.getDeclaringClass().isInterface()) {
+							continue;
+						}
+						if(Modifier.isStatic(method.getModifiers())) {
+							continue;
+						}else {
+							//getter type
+							if(method.getName().matches("(get|is)[A-Z].*")) {
+								String name;
+								if(method.getName().startsWith("get")) {
+									name = method.getName().substring("get".length(), "get".length() + 1).toLowerCase() + method.getName().substring("get".length() + 1);
+								}else {
+									name = method.getName().substring("is".length(), "is".length() + 1).toLowerCase() + method.getName().substring("is".length() + 1);
+								}
+
+								GraphQLFieldDefinition.Builder field = GraphQLFieldDefinition.newFieldDefinition();
+								field.name(name);
+
+
+								TypeMeta meta = new TypeMeta(this, type, method.getReturnType(), method.getGenericReturnType());
+								field.type(SchemaBuilder.getType(meta, method.getAnnotations()));
+								graphType.field(field);
+								interfaceBuilder.field(field);
+
+								if(method.getParameterCount() > 0 || directives.target(method, meta)) {
+									codeRegistry.dataFetcher(FieldCoordinates.coordinates(typeName, name), buildDirectiveWrapper(directives, method, meta));
+								}
+							}else if(method.getName().matches("set[A-Z].*")) {
+								if(method.getParameterCount() == 1 && !method.isAnnotationPresent(InputIgnore.class)) {
+									String name = method.getName().substring("set".length(), "set".length() + 1).toLowerCase() + method.getName().substring("set".length() + 1);
+									GraphQLInputObjectField.Builder field = GraphQLInputObjectField.newInputObjectField();
+									field.name(name);
+									TypeMeta meta = new TypeMeta(this, genericType, method.getParameterTypes()[0], method.getGenericParameterTypes()[0]);
+									field.type(SchemaBuilder.getInputType(meta, method.getParameterAnnotations()[0]));
+									graphInputType.field(field);
+								}
+							}
+						}
+					}catch(RuntimeException e) {
+						throw new RuntimeException("Failed to process method " + method, e);
+					}
+				}
+
+				if(type.isInterface() || Modifier.isAbstract(type.getModifiers())) {
+					GraphQLInterfaceType built = interfaceBuilder.build();
+					if(additionalTypes.put(built.getName(), built) != null) {
+						throw new RuntimeException(built.getName() + "defined more than once");
+					}
+
+					codeRegistry.typeResolver(built.getName(), env -> {
+						if(type.isInstance(env.getObject())) {	
+							return (GraphQLObjectType) additionalTypes.get(getName(env.getObject().getClass(), env.getObject().getClass()));
+						}
+						return null;
+					});
+					return;
+				}
+				Class<?> parent = type.getSuperclass();
+				while(parent != null) {
+					if(parent.isAnnotationPresent(Entity.class)) {
+						String interfaceName = process(parent, type.getGenericSuperclass());
+						graphType.withInterface(GraphQLTypeReference.typeRef(interfaceName));
+					}
+					parent = parent.getSuperclass();
+				}
+
+				if(schemaType == SchemaOption.BOTH || schemaType == SchemaOption.TYPE) {
+					GraphQLObjectType built = graphType.build();
+					if(additionalTypes.put(built.getName(), built) != null) {
+						throw new RuntimeException(built.getName() + "defined more than once");
+					}
+					codeRegistry.typeResolver(built.getName(), env -> {
+						if(type.isInstance(env.getObject())) {	
+							return built;
+						}
+						return null;
+					});
+				}
+				if(schemaType == SchemaOption.BOTH || schemaType == SchemaOption.INPUT) {
+					GraphQLInputObjectType inputBuild = graphInputType.build();
+					if(additionalTypes.put(inputBuild.getName(), inputBuild) != null) {
+						throw new RuntimeException(inputBuild.getName() + " defined more than once");
+					}
+				}
+			}
+		}catch (ReflectiveOperationException | RuntimeException e) {
+			throw new RuntimeException("Failed to build schema for class " + type, e);
+		}
+	}
+	
+	private static <T extends Annotation> DataFetcher<?> buildDirectiveWrapper(DirectivesSchema diretives, Method method, TypeMeta meta) {
+		DataFetcher<?> fetcher = env -> {
+			Object[] args = new Object[method.getParameterCount()];
+			for(int i = 0; i < args.length; i++) {
+
+				if(method.getParameterTypes()[i].isAssignableFrom(env.getClass())) {
+					args[i] = env;
+				}else if(method.getParameterTypes()[i].isAssignableFrom(env.getContext().getClass())) {
+					args[i] = env.getContext();
+				}else {
+					Object obj = env.getArgument(method.getParameters()[i].getName());
+					args[i] = obj;
+				}
+			}
+			try {
+				return method.invoke(env.getSource(), args);
+			}catch (Exception e) {
+				System.out.println(method);
+				System.out.println((Object) env.getSource());
+				System.out.println(Arrays.toString(args));
+				if(e.getCause() instanceof Exception) {
+					throw (Exception) e.getCause();
+				}else {
+					throw e;
+				}
+
+			}
+		};
+
+		fetcher = diretives.wrap(method, meta, fetcher);
+		return fetcher;
+
+	}
+
+	
+	private String getName(Class<?> type, Type genericType) {
+
+		String name = null;
+
+		if(type.isEnum()) {
+			name = type.getSimpleName();
+		}
+		if(type.isAnnotationPresent(Scalar.class)) {
+			name = type.getSimpleName();
+		}
+		if(type.isAnnotationPresent(Entity.class)) {
+			name = type.getSimpleName();
+		}
+		
+		if(genericType instanceof ParameterizedType) {
+			var parameterizedTypes = ((ParameterizedType) genericType).getActualTypeArguments();
+			
+			for(var t: parameterizedTypes) {
+				if(t instanceof Class) {
+					String extra = ((Class) t).getSimpleName();
+					name += "_" + extra;
+					
+				}	
+			}
+			
+			System.out.println(genericType);
+		}
+		
+		return name;
+	}
+
+	public String process(Class<?> type, Type genericType) {
+		String name = getName(type, genericType);
+				if(name != null && !this.additionalTypes.containsKey(name)) {
+			addType(type, genericType, false);
+		}
+		return name;
+	}
+
+	private String getNameInput(Class<?> type, Type genericType) {
+		
+		String name = null;
+		if(type.isEnum()) {
+			name = type.getSimpleName();
+		}
+		
+		if(type.isAnnotationPresent(Scalar.class)) {
+			name = type.getSimpleName();
+		}
+		
+		if(type.isAnnotationPresent(Entity.class)) {
+			if(type.getAnnotation(Entity.class).value() == SchemaOption.BOTH) {
+				name = type.getSimpleName() + "Input";
+			}else {
+				name = type.getSimpleName();
+			}
+		}
+		
+		if(genericType instanceof ParameterizedType) {
+			var parameterizedTypes = ((ParameterizedType) genericType).getActualTypeArguments();
+			
+			for(var t: parameterizedTypes) {
+				if(t instanceof Class) {
+					String extra = ((Class) t).getSimpleName();
+					name += "_" + extra;
+					
+				}	
+			}
+			
+			System.out.println(name);
+		}
+		
+		return name;
+	}
+
+
+	public String processInput(Class<?> type, Type genericType) {
+		String name = getNameInput(type, genericType);
+		if(name != null && !this.additionalTypes.containsKey(name)) {
+			addType(type, genericType, true);
+		}
+		return name;
+	}
+
+}

--- a/src/main/java/com/fleetpin/graphql/builder/SchemaBuilder.java
+++ b/src/main/java/com/fleetpin/graphql/builder/SchemaBuilder.java
@@ -53,32 +53,24 @@ import com.fleetpin.graphql.builder.TypeMeta.Flag;
 import com.fleetpin.graphql.builder.annotations.Context;
 import com.fleetpin.graphql.builder.annotations.Directive;
 import com.fleetpin.graphql.builder.annotations.Entity;
-import com.fleetpin.graphql.builder.annotations.GraphQLIgnore;
 import com.fleetpin.graphql.builder.annotations.Id;
-import com.fleetpin.graphql.builder.annotations.InputIgnore;
 import com.fleetpin.graphql.builder.annotations.Mutation;
 import com.fleetpin.graphql.builder.annotations.Query;
 import com.fleetpin.graphql.builder.annotations.Restrict;
 import com.fleetpin.graphql.builder.annotations.Scalar;
-import com.fleetpin.graphql.builder.annotations.SchemaOption;
 import com.fleetpin.graphql.builder.annotations.Subscription;
 
 import graphql.GraphQL;
 import graphql.Scalars;
 import graphql.introspection.Introspection.DirectiveLocation;
-import graphql.schema.Coercing;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.FieldCoordinates;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirective;
-import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLInputObjectField;
-import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLInputType;
-import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
@@ -88,7 +80,6 @@ import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeReference;
-import graphql.schema.idl.TypeRuntimeWiring;
 
 public class SchemaBuilder {
 	public final static ObjectMapper MAPPER = new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).registerModule(new ParameterNamesModule())
@@ -104,35 +95,42 @@ public class SchemaBuilder {
 	private static final GraphQLScalarType MONTH_DAY_SCALAR = GraphQLScalarType.newScalar().name("MonthDay").coercing(new MonthDayCoercing()).build();
 	private static final GraphQLScalarType YEAR_MONTH_SCALAR = GraphQLScalarType.newScalar().name("YearMonth").coercing(new YearMonthCoercing()).build();
 
+	private final DirectivesSchema diretives;
+	private final AuthorizerSchema authorizer;
 
-	private static graphql.GraphQL.Builder build(DirectivesSchema diretives, AuthorizerSchema authorizer, Set<Class<?>> types, Set<Class<?>> scalars, Set<Method> endPoints) throws ReflectiveOperationException {
-		Builder graphQuery = GraphQLObjectType.newObject();
+	private final GraphQLCodeRegistry.Builder codeRegistry;
+	private final GraphQLDirective directive;
+
+	private final Map<String, GraphQLType> additionalTypes;
+	
+	private final Builder graphQuery;
+	private final Builder graphMutations;
+	private final Builder graphSubscriptions;
+	
+	private final EntityProcessor entityProcessor;
+
+	
+	private SchemaBuilder(DirectivesSchema diretives, AuthorizerSchema authorizer) {
+		this.diretives = diretives;
+		this.authorizer = authorizer;
+		
+		this.graphQuery = GraphQLObjectType.newObject();
 		graphQuery.name("Query");
-		Builder graphMutations = GraphQLObjectType.newObject();
+		this.graphMutations = GraphQLObjectType.newObject();
 		graphMutations.name("Mutations");
-		Builder graphSubscriptions = GraphQLObjectType.newObject();
+		this.graphSubscriptions = GraphQLObjectType.newObject();
 		graphSubscriptions.name("Subscriptions");
-		Map<String, GraphQLType> additionalTypes = new HashMap<>();
-		GraphQLCodeRegistry.Builder codeRegistry = GraphQLCodeRegistry.newCodeRegistry();
+		this.additionalTypes = new HashMap<>();
+		this.codeRegistry = GraphQLCodeRegistry.newCodeRegistry();
 
+		this.entityProcessor = new EntityProcessor(additionalTypes, codeRegistry, diretives);
 
-		GraphQLDirective directive = GraphQLDirective.newDirective()
+		this.directive = GraphQLDirective.newDirective()
 				.name("authorization")
 				.validLocation(DirectiveLocation.FIELD_DEFINITION).build();
-
-		for(Class<?> scalar: scalars) {
-			GraphQLScalarType.Builder scalarType = GraphQLScalarType.newScalar();
-			String typeName = getName(scalar);
-			scalarType.name(typeName);
-			Class<? extends Coercing> coerecing = scalar.getAnnotation(Scalar.class).value();
-			scalarType.coercing(coerecing.getDeclaredConstructor().newInstance());
-			var built = scalarType.build();
-			if(additionalTypes.put(built.getName(), built) != null) {
-				throw new RuntimeException(built.getName() + "defined more than once");
-			}
-			continue;			
-		}
-
+	}
+	
+	private SchemaBuilder process(Set<Method> endPoints) throws ReflectiveOperationException {
 		for(var method: endPoints) {
 			if(!Modifier.isStatic(method.getModifiers())) {
 				throw new RuntimeException("End point must be a static method");
@@ -141,14 +139,16 @@ public class SchemaBuilder {
 			GraphQLFieldDefinition.Builder field = GraphQLFieldDefinition.newFieldDefinition();
 			field.name(method.getName());
 
-			TypeMeta meta = new TypeMeta(null, method.getReturnType(), method.getGenericReturnType());
+			TypeMeta meta = new TypeMeta(entityProcessor, null, method.getReturnType(), method.getGenericReturnType());
 			field.type(getType(meta, method.getAnnotations()));
 			for(int i = 0; i < method.getParameterCount(); i++) {
 				GraphQLArgument.Builder argument = GraphQLArgument.newArgument();
 				if(isContext(method.getParameterTypes()[i])) {
 					continue;
 				}
-				argument.type(getInputType(null, method.getParameterTypes()[i], method.getGenericParameterTypes()[i], method.getParameterAnnotations()[i]));//TODO:dirty cast
+				
+				TypeMeta inputMeta = new TypeMeta(this.entityProcessor, null, method.getParameterTypes()[i], method.getGenericParameterTypes()[i]);
+				argument.type(getInputType(inputMeta, method.getParameterAnnotations()[i]));//TODO:dirty cast
 				argument.name(method.getParameters()[i].getName());
 				//TODO: argument.defaultValue(defaultValue)
 				field.argument(argument);
@@ -172,209 +172,19 @@ public class SchemaBuilder {
 			}
 
 		}
+		return this;
+	}
 
-
-		for(Class<?> type: types) {
-			try {
-				//special handling
-				if(type.isEnum()) {
-					graphql.schema.GraphQLEnumType.Builder enumType = GraphQLEnumType.newEnum();
-					String typeName = getName(type);
-					enumType.name(typeName);
-
-					Object[] enums = type.getEnumConstants();
-					for(Object e: enums) {
-						Enum a = (Enum) e;
-						if(type.getDeclaredField(e.toString()).isAnnotationPresent(GraphQLIgnore.class)) {
-							continue;
-						}
-						enumType.value(a.name(), a);
-					}
-					GraphQLEnumType built = enumType.build();
-					if(additionalTypes.put(built.getName(), built) != null) {
-						throw new RuntimeException(built.getName() + "defined more than once");
-					}
-					continue;
-				}
-
-				SchemaOption schemaType = SchemaOption.BOTH;
-				Entity graphTypeAnnotation = type.getAnnotation(Entity.class);
-				if(graphTypeAnnotation != null) {
-					schemaType = graphTypeAnnotation.value();
-				}
-
-				Builder graphType = GraphQLObjectType.newObject();
-				String typeName = getName(type);
-				graphType.name(typeName);
-
-
-				GraphQLInterfaceType.Builder interfaceBuilder = GraphQLInterfaceType.newInterface();
-				interfaceBuilder.name(typeName);
-
-				GraphQLInputObjectType.Builder graphInputType = GraphQLInputObjectType.newInputObject();
-				if(schemaType == SchemaOption.INPUT) {
-					graphInputType.name(typeName);
-				}else {
-					graphInputType.name(typeName + "Input");
-				}
-
-				{
-					GraphQLInputObjectField.Builder field = GraphQLInputObjectField.newInputObjectField();
-					field.name("__typename");
-					field.type(Scalars.GraphQLString);
-					graphInputType.field(field);
-				}
-
-
-				TypeRuntimeWiring.Builder runtime = new TypeRuntimeWiring.Builder();
-				runtime.typeName(typeName);
-				for(Method method: type.getMethods()) {
-					try {
-						if(method.isSynthetic()) {
-							continue;
-						}
-						if(method.getDeclaringClass().equals(Object.class)) {
-							continue;
-						}
-						if(method.isAnnotationPresent(GraphQLIgnore.class)) {
-							continue;
-						}
-						//will also be on implementing class
-						if(Modifier.isAbstract(method.getModifiers()) || method.getDeclaringClass().isInterface()) {
-							continue;
-						}
-						if(Modifier.isStatic(method.getModifiers())) {
-							continue;
-						}else {
-							//getter type
-							if(method.getName().matches("(get|is)[A-Z].*")) {
-								String name;
-								if(method.getName().startsWith("get")) {
-									name = method.getName().substring("get".length(), "get".length() + 1).toLowerCase() + method.getName().substring("get".length() + 1);
-								}else {
-									name = method.getName().substring("is".length(), "is".length() + 1).toLowerCase() + method.getName().substring("is".length() + 1);
-								}
-
-								GraphQLFieldDefinition.Builder field = GraphQLFieldDefinition.newFieldDefinition();
-								field.name(name);
-
-
-								TypeMeta meta = new TypeMeta(type, method.getReturnType(), method.getGenericReturnType());
-								field.type(getType(meta, method.getAnnotations()));
-								graphType.field(field);
-								interfaceBuilder.field(field);
-
-								if(method.getParameterCount() > 0 || diretives.target(method, meta)) {
-									codeRegistry.dataFetcher(FieldCoordinates.coordinates(typeName, name), buildDirectiveWrapper(diretives, method, meta));
-								}
-							}else if(method.getName().matches("set[A-Z].*")) {
-								if(method.getParameterCount() == 1 && !method.isAnnotationPresent(InputIgnore.class)) {
-									String name = method.getName().substring("set".length(), "set".length() + 1).toLowerCase() + method.getName().substring("set".length() + 1);
-									GraphQLInputObjectField.Builder field = GraphQLInputObjectField.newInputObjectField();
-									field.name(name);
-									field.type(getInputType(type, method.getParameterTypes()[0], method.getGenericParameterTypes()[0], method.getParameterAnnotations()[0]));
-									graphInputType.field(field);
-								}
-							}
-						}
-					}catch(RuntimeException e) {
-						throw new RuntimeException("Failed to process method " + method, e);
-					}
-				}
-
-				if(type.isInterface() || Modifier.isAbstract(type.getModifiers())) {
-					GraphQLInterfaceType built = interfaceBuilder.build();
-					if(additionalTypes.put(built.getName(), built) != null) {
-						throw new RuntimeException(built.getName() + "defined more than once");
-					}
-
-					codeRegistry.typeResolver(built.getName(), env -> {
-						if(type.isInstance(env.getObject())) {	
-							return (GraphQLObjectType) additionalTypes.get(getName(env.getObject().getClass()));
-						}
-						return null;
-					});
-
-					continue;
-				}
-				Class<?> parent = type.getSuperclass();
-				while(parent != null) {
-					if(parent.isAnnotationPresent(Entity.class)) {
-						String interfaceName = getName(parent);
-						graphType.withInterface(GraphQLTypeReference.typeRef(interfaceName));
-					}
-					parent = parent.getSuperclass();
-				}
-
-				if(schemaType == SchemaOption.BOTH || schemaType == SchemaOption.TYPE) {
-					GraphQLObjectType built = graphType.build();
-					if(additionalTypes.put(built.getName(), built) != null) {
-						throw new RuntimeException(built.getName() + "defined more than once");
-					}
-					codeRegistry.typeResolver(built.getName(), env -> {
-						if(type.isInstance(env.getObject())) {	
-							return built;
-						}
-						return null;
-					});
-				}
-				if(schemaType == SchemaOption.BOTH || schemaType == SchemaOption.INPUT) {
-					GraphQLInputObjectType inputBuild = graphInputType.build();
-					if(additionalTypes.put(inputBuild.getName(), inputBuild) != null) {
-						throw new RuntimeException(inputBuild.getName() + " defined more than once");
-					}
-				}
-
-			}catch(RuntimeException e) {
-				throw new RuntimeException("Failed to build schema for class " + type, e);
-			}
-
-		}
+	private graphql.GraphQL.Builder build() {
 		codeRegistry.typeResolver("ID", env -> {
 			return null;
 		});
-
-
 		return GraphQL.newGraphQL(GraphQLSchema.newSchema().codeRegistry(codeRegistry.build()).additionalTypes(new HashSet<>(additionalTypes.values())).query(graphQuery.build()).mutation(graphMutations).subscription(graphSubscriptions).additionalDirective(directive).build());
 
 	}
 
 	private static boolean isContext(Class<?> class1) {
 		return class1.isAssignableFrom(DataFetchingEnvironment.class) || class1.isAnnotationPresent(Context.class);
-	}
-
-	private static <T extends Annotation> DataFetcher<?> buildDirectiveWrapper(DirectivesSchema diretives, Method method, TypeMeta meta) {
-		DataFetcher<?> fetcher = env -> {
-			Object[] args = new Object[method.getParameterCount()];
-			for(int i = 0; i < args.length; i++) {
-
-				if(method.getParameterTypes()[i].isAssignableFrom(env.getClass())) {
-					args[i] = env;
-				}else if(method.getParameterTypes()[i].isAssignableFrom(env.getContext().getClass())) {
-					args[i] = env.getContext();
-				}else {
-					Object obj = env.getArgument(method.getParameters()[i].getName());
-					args[i] = obj;
-				}
-			}
-			try {
-				return method.invoke(env.getSource(), args);
-			}catch (Exception e) {
-				System.out.println(method);
-				System.out.println((Object) env.getSource());
-				System.out.println(Arrays.toString(args));
-				if(e.getCause() instanceof Exception) {
-					throw (Exception) e.getCause();
-				}else {
-					throw e;
-				}
-
-			}
-		};
-
-		fetcher = diretives.wrap(method, meta, fetcher);
-		return fetcher;
-
 	}
 
 	private static <T extends Annotation> DataFetcher<?> buildFetcher(DirectivesSchema diretives, AuthorizerSchema authorizer, Method method, TypeMeta meta) {
@@ -416,7 +226,13 @@ public class SchemaBuilder {
 									}));
 								}
 							}else {
-								args[i] = MAPPER.convertValue(obj, method.getParameters()[i].getType());	
+								var t = method.getParameters()[i].getParameterizedType();
+								args[i] = MAPPER.convertValue(obj, new TypeReference<Object>() {
+									@Override
+									public Type getType() {
+										return t;
+									}
+								});
 							}
 						}
 					}
@@ -444,23 +260,10 @@ public class SchemaBuilder {
 		return fetcher;
 	}
 
-	public static Class<?> extraOptionalType(Type type) {
-		if(type instanceof Class) {
-			return (Class<?>) type;
-		}else if(type instanceof ParameterizedType){
-			return extraOptionalType(((ParameterizedType) type).getActualTypeArguments()[0]);
-		}
-		throw new RuntimeException("extraction failure for " + type.getClass());
-	}
-
-	private static String getName(Class<?> type) {
-		return type.getSimpleName();
-	}
-
-	private static GraphQLOutputType getType(TypeMeta meta, Annotation[] annotations) {
+	static GraphQLOutputType getType(TypeMeta meta, Annotation[] annotations) {
 		
 		
-		GraphQLOutputType toReturn = getTypeInner(meta.getType(), annotations);
+		GraphQLOutputType toReturn = getTypeInner(meta.getType(), annotations, meta.getName());
 		boolean required = true;
 		for(var flag: meta.getFlags()) {
 			if(flag == Flag.OPTIONAL) {
@@ -482,7 +285,7 @@ public class SchemaBuilder {
 	}
 	
 	
-	private static GraphQLOutputType getTypeInner(Class<?> type, Annotation[] annotations) {
+	private static GraphQLOutputType getTypeInner(Class<?> type, Annotation[] annotations, String name) {
 		for(Annotation an: annotations) {
 			if(an.annotationType().equals(Id.class)) {
 				return Scalars.GraphQLID;
@@ -527,25 +330,24 @@ public class SchemaBuilder {
 		
 		
 		if(type.isEnum()) {
-			return GraphQLTypeReference.typeRef(getName(type));
+			return GraphQLTypeReference.typeRef(name);
 		}
 		
 		if(type.isAnnotationPresent(Entity.class)) {
-			return GraphQLTypeReference.typeRef(getName(type));
+			return GraphQLTypeReference.typeRef(name);
 		}
 		
 		if(type.isAnnotationPresent(Scalar.class)) {
-			return GraphQLTypeReference.typeRef(getName(type));
+			return GraphQLTypeReference.typeRef(name);
 		}
 		
 		throw new RuntimeException("Unsupport type " + type);
 	}
 	
 	
-	private static GraphQLInputType getInputType(Class<?> owningClass, Class<?> type, Type genericType, Annotation[] annotations) {
+	static GraphQLInputType getInputType(TypeMeta meta, Annotation[] annotations) {
 		
-		TypeMeta meta = new TypeMeta(owningClass, type, genericType);
-		GraphQLInputType toReturn = getInputTypeInner(meta.getType(), annotations);
+		GraphQLInputType toReturn = getInputTypeInner(meta.getType(), annotations, meta.getInputName());
 		
 		boolean required = true;
 		for(var flag: meta.getFlags()) {
@@ -566,7 +368,7 @@ public class SchemaBuilder {
 		return toReturn;
 	}
 	
-	private static GraphQLInputType getInputTypeInner(Class<?> type, Annotation[] annotations) {
+	private static GraphQLInputType getInputTypeInner(Class<?> type, Annotation[] annotations, String name) {
 
 		for(Annotation an: annotations) {
 			if(an.annotationType().equals(Id.class)) {
@@ -614,20 +416,16 @@ public class SchemaBuilder {
 		
 		
 		if(type.isEnum()) {
-			return GraphQLTypeReference.typeRef(getName(type));
+			return GraphQLTypeReference.typeRef(name);
 		}
 		
 		if(type.isAnnotationPresent(Scalar.class)) {
-			return GraphQLTypeReference.typeRef(getName(type));
+			return GraphQLTypeReference.typeRef(name);
 		}
 		
 		
 		if(type.isAnnotationPresent(Entity.class)) {
-			if(type.getAnnotation(Entity.class).value() == SchemaOption.BOTH) {
-				return GraphQLTypeReference.typeRef(getName(type) + "Input");
-			}else {
-				return GraphQLTypeReference.typeRef(getName(type));
-			}
+			return GraphQLTypeReference.typeRef(name);
 		}
 		
 		throw new RuntimeException("Unsupport type " + type);
@@ -637,7 +435,6 @@ public class SchemaBuilder {
 		
 		
 		Reflections reflections = new Reflections(classPath, new SubTypesScanner(), new MethodAnnotationsScanner(), new TypeAnnotationsScanner());
-		System.out.println(reflections.getConfiguration().getScanners());
 		Set<Class<? extends Authorizer>> authorizers = reflections.getSubTypesOf(Authorizer.class);
 		//want to make everything split by package
 		AuthorizerSchema authorizer = AuthorizerSchema.build(new HashSet<>(Arrays.asList(classPath)), authorizers);
@@ -676,7 +473,9 @@ public class SchemaBuilder {
 		types.removeIf(t -> t.isAnonymousClass());
 		scalars.removeIf(t -> t.isAnonymousClass());
 		
-		return build(diretivesSchema, authorizer, types, scalars, endPoints);
+		return new SchemaBuilder(diretivesSchema, authorizer).process(endPoints).build();
 	}
 
+
+	
 }

--- a/src/test/java/com/fleetpin/graphql/builder/TypeGenericInputParsingTest.java
+++ b/src/test/java/com/fleetpin/graphql/builder/TypeGenericInputParsingTest.java
@@ -1,0 +1,202 @@
+package com.fleetpin.graphql.builder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+
+public class TypeGenericInputParsingTest {
+
+	@Test
+	public void testAnimalName() throws ReflectiveOperationException {
+		var name = getField("Animal", "INTERFACE", "name");
+		var nonNull = confirmNonNull(name);
+		confirmString(nonNull);
+	}
+
+	@Test
+	public void testCatName() throws ReflectiveOperationException {
+		var name = getField("Cat", "OBJECT", "name");
+		var nonNull = confirmNonNull(name);
+		confirmString(nonNull);
+	}
+	
+	@Test
+	public void testCatInputName() throws ReflectiveOperationException {
+		var name = getInputField("CatInput", "INPUT_OBJECT", "name");
+		var nonNull = confirmNonNull(name);
+		confirmString(nonNull);
+	}
+	
+	@Test
+	public void testCatInputFur() throws ReflectiveOperationException {
+		var name = getInputField("CatInput", "INPUT_OBJECT", "fur");
+		var nonNull = confirmNonNull(name);
+		confirmBoolean(nonNull);
+	}
+	
+	
+	@Test
+	public void testAnimalInputName() throws ReflectiveOperationException {
+		var name = getInputField("CatAnimalInput", "INPUT_OBJECT", "id");
+		var nonNull = confirmNonNull(name);
+		confirmString(nonNull);
+	}
+	
+	
+	@Test
+	public void testAnimalInputGenericName() throws ReflectiveOperationException {
+		var name = getInputField("AnimalInput_Cat", "INPUT_OBJECT", "id");
+		var nonNull = confirmNonNull(name);
+		confirmString(nonNull);
+	}
+	
+	
+	@Test
+	public void testAnimalInputCat() throws ReflectiveOperationException {
+		var name = getInputField("CatAnimalInput", "INPUT_OBJECT", "animal");
+		var nonNull = confirmNonNull(name);
+		confirmInputObject(nonNull, "CatInput");
+
+	}
+	
+	@Test
+	public void testAnimalInputGenericCat() throws ReflectiveOperationException {
+		var name = getInputField("AnimalInput_Cat", "INPUT_OBJECT", "animal");
+		var nonNull = confirmNonNull(name);
+		confirmInputObject(nonNull, "CatInput");
+
+	}
+	
+	
+	private void confirmString(Map<String, Object> type) {
+		Assertions.assertEquals("SCALAR", type.get("kind"));
+		Assertions.assertEquals("String", type.get("name"));
+	}
+
+
+	private void confirmInputObject(Map<String, Object> type, String name) {
+		Assertions.assertEquals("INPUT_OBJECT", type.get("kind"));
+		Assertions.assertEquals(name, type.get("name"));
+	}
+
+
+	private Map<String, Object> confirmNonNull(Map<String, Object> type) {
+		Assertions.assertEquals("NON_NULL", type.get("kind"));
+		var toReturn = (Map<String, Object>) type.get("ofType");
+		Assertions.assertNotNull(toReturn);
+		return toReturn;
+	}
+	
+	private void confirmBoolean(Map<String, Object> type) {
+		Assertions.assertEquals("SCALAR", type.get("kind"));
+		Assertions.assertEquals("Boolean", type.get("name"));
+	}
+	
+	public Map<String, Object> getField(String typeName, String kind, String name) throws ReflectiveOperationException {
+		Map<String, Map<String, Object>> response = execute("{" + 
+				"  __type(name: \"" + typeName + "\") {" + 
+				"    name" + 
+				"    kind" +	
+				"    fields {" + 
+				"      name" + 
+				"      type {" + 
+				"        name" + 
+				"        kind" +
+				"        ofType {" + 
+				"          name" + 
+				"          kind" +
+				"          ofType {" + 
+				"            name" + 
+				"            kind" +
+				"            ofType {" + 
+				"              name" + 
+				"              kind" + 
+				"            }" +
+				"          }" +
+				"        }" +
+				"      }" + 
+				"    }" + 
+				"  }" + 
+				"} ").getData();
+		var type = response.get("__type");
+		Assertions.assertEquals(typeName, type.get("name"));
+		Assertions.assertEquals(kind, type.get("kind"));
+		List<Map<String, Object>> fields = (List<Map<String, Object>>) type.get("fields");
+		var field = fields.stream().filter(map -> map.get("name").equals(name)).findAny().get();
+		Assertions.assertEquals(name, field.get("name"));
+		return (Map<String, Object>) field.get("type");
+	}
+	
+	public Map<String, Object> getInputField(String typeName, String kind, String name) throws ReflectiveOperationException {
+		Map<String, Map<String, Object>> response = execute("{" + 
+				"  __type(name: \"" + typeName + "\") {" + 
+				"    name" + 
+				"    kind" +	
+				"    inputFields {" + 
+				"      name" + 
+				"      type {" + 
+				"        name" + 
+				"        kind" +
+				"        ofType {" + 
+				"          name" + 
+				"          kind" +
+				"          ofType {" + 
+				"            name" + 
+				"            kind" +
+				"            ofType {" + 
+				"              name" + 
+				"              kind" + 
+				"            }" +
+				"          }" +
+				"        }" +
+				"      }" + 
+				"    }" + 
+				"  }" + 
+				"} ").getData();
+		var type = response.get("__type");
+		Assertions.assertEquals(typeName, type.get("name"));
+		Assertions.assertEquals(kind, type.get("kind"));
+		List<Map<String, Object>> fields = (List<Map<String, Object>>) type.get("inputFields");
+		var field = fields.stream().filter(map -> map.get("name").equals(name)).findAny().get();
+		Assertions.assertEquals(name, field.get("name"));
+		return (Map<String, Object>) field.get("type");
+	}
+
+	@Test
+	public void testQueryCatFur() throws ReflectiveOperationException {
+		Map<String, String> response = execute("mutation {addCat(input: {id: \"1\", animal: {name: \"felix\", fur: false}})} ").getData();
+		var cat = response.get("addCat");
+		assertEquals("felix", cat);
+	}
+	
+	@Test
+	public void testQueryCatFurGeneric() throws ReflectiveOperationException {
+		Map<String, Boolean> response = execute("mutation {addCatGenerics(input: {id: \"1\", animal: {name: \"felix\", fur: true}})} ").getData();
+		var cat = response.get("addCatGenerics");
+		assertEquals(true, cat);
+	}
+
+
+
+	private ExecutionResult execute(String query) {
+		try {
+			GraphQL schema = SchemaBuilder.build("com.fleetpin.graphql.builder.inputgenerics").build();
+			ExecutionResult result = schema.execute(query);
+			if(!result.getErrors().isEmpty()) {
+				throw new RuntimeException(result.getErrors().toString());
+			}
+			return result;
+		} catch (ReflectiveOperationException e) {
+			throw new RuntimeException(e);
+		}
+
+	}
+
+}

--- a/src/test/java/com/fleetpin/graphql/builder/generics/Cat.java
+++ b/src/test/java/com/fleetpin/graphql/builder/generics/Cat.java
@@ -1,12 +1,18 @@
 package com.fleetpin.graphql.builder.generics;
 
 import com.fleetpin.graphql.builder.annotations.Entity;
+import com.fleetpin.graphql.builder.annotations.Mutation;
 
 @Entity
 public class Cat extends CatFamily<CatFur>{
 
 	public Cat() {
 		super(new CatFur());
+	}
+	
+	@Mutation
+	public static Cat getCat() {
+		return null;
 	}
 	
 }

--- a/src/test/java/com/fleetpin/graphql/builder/generics/Dog.java
+++ b/src/test/java/com/fleetpin/graphql/builder/generics/Dog.java
@@ -1,6 +1,7 @@
 package com.fleetpin.graphql.builder.generics;
 
 import com.fleetpin.graphql.builder.annotations.Entity;
+import com.fleetpin.graphql.builder.annotations.Mutation;
 
 @Entity
 public class Dog extends Animal<DogFur> {
@@ -11,5 +12,10 @@ public class Dog extends Animal<DogFur> {
 
 	public int getAge() {
 		return 6;
+	}
+	
+	@Mutation
+	public static Dog getDog() {
+		return null;
 	}
 }

--- a/src/test/java/com/fleetpin/graphql/builder/inputgenerics/Animal.java
+++ b/src/test/java/com/fleetpin/graphql/builder/inputgenerics/Animal.java
@@ -1,0 +1,18 @@
+package com.fleetpin.graphql.builder.inputgenerics;
+
+import com.fleetpin.graphql.builder.annotations.Entity;
+
+@Entity
+public abstract class Animal {
+
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+}

--- a/src/test/java/com/fleetpin/graphql/builder/inputgenerics/AnimalInput.java
+++ b/src/test/java/com/fleetpin/graphql/builder/inputgenerics/AnimalInput.java
@@ -1,0 +1,27 @@
+package com.fleetpin.graphql.builder.inputgenerics;
+
+import com.fleetpin.graphql.builder.annotations.Entity;
+import com.fleetpin.graphql.builder.annotations.SchemaOption;
+
+@Entity(SchemaOption.INPUT)
+public class AnimalInput<T extends Animal> {
+	String id;
+	T animal;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public T getAnimal() {
+		return animal;
+	}
+
+	public void setAnimal(T animal) {
+		this.animal = animal;
+	}
+
+}

--- a/src/test/java/com/fleetpin/graphql/builder/inputgenerics/Cat.java
+++ b/src/test/java/com/fleetpin/graphql/builder/inputgenerics/Cat.java
@@ -1,0 +1,32 @@
+package com.fleetpin.graphql.builder.inputgenerics;
+
+import com.fleetpin.graphql.builder.annotations.Entity;
+import com.fleetpin.graphql.builder.annotations.Mutation;
+import com.fleetpin.graphql.builder.annotations.SchemaOption;
+
+@Entity(SchemaOption.BOTH)
+public class Cat extends Animal {
+	
+	private boolean fur;
+	
+	
+	public void setFur(boolean fur) {
+		this.fur = fur;
+	}
+	
+	public boolean isFur() {
+		return fur;
+	}
+	
+	@Mutation
+	public static String addCat(CatAnimalInput input) {
+		return input.getAnimal().getName();
+	}
+	
+	
+	@Mutation
+	public static boolean addCatGenerics(AnimalInput<Cat> input) {
+		return input.getAnimal().isFur();
+	}
+
+}

--- a/src/test/java/com/fleetpin/graphql/builder/inputgenerics/CatAnimalInput.java
+++ b/src/test/java/com/fleetpin/graphql/builder/inputgenerics/CatAnimalInput.java
@@ -1,0 +1,9 @@
+package com.fleetpin.graphql.builder.inputgenerics;
+
+import com.fleetpin.graphql.builder.annotations.Entity;
+import com.fleetpin.graphql.builder.annotations.SchemaOption;
+
+@Entity(SchemaOption.INPUT)
+public class CatAnimalInput extends AnimalInput<Cat> {
+
+}

--- a/src/test/java/com/fleetpin/graphql/builder/type/Circular.java
+++ b/src/test/java/com/fleetpin/graphql/builder/type/Circular.java
@@ -1,0 +1,19 @@
+
+package com.fleetpin.graphql.builder.type;
+
+import com.fleetpin.graphql.builder.annotations.Entity;
+import com.fleetpin.graphql.builder.annotations.Mutation;
+
+@Entity
+public class Circular {
+
+	public Circular getCircular()  {
+		return null;
+	}
+	
+	
+	@Mutation
+	public static Circular circularTest() {
+		return new Circular();
+	}
+}

--- a/src/test/java/com/fleetpin/graphql/builder/type/inheritance/Cat.java
+++ b/src/test/java/com/fleetpin/graphql/builder/type/inheritance/Cat.java
@@ -1,6 +1,7 @@
 package com.fleetpin.graphql.builder.type.inheritance;
 
 import com.fleetpin.graphql.builder.annotations.Entity;
+import com.fleetpin.graphql.builder.annotations.Mutation;
 
 @Entity
 public class Cat extends Animal{
@@ -16,4 +17,10 @@ public class Cat extends Animal{
 	public boolean getFur() {
 		return true;
 	}
+	
+	@Mutation
+	public static Cat getCat() {
+		return null;
+	}
 }
+

--- a/src/test/java/com/fleetpin/graphql/builder/type/inheritance/Dog.java
+++ b/src/test/java/com/fleetpin/graphql/builder/type/inheritance/Dog.java
@@ -1,6 +1,7 @@
 package com.fleetpin.graphql.builder.type.inheritance;
 
 import com.fleetpin.graphql.builder.annotations.Entity;
+import com.fleetpin.graphql.builder.annotations.Mutation;
 
 @Entity
 public class Dog extends Animal{
@@ -10,5 +11,10 @@ public class Dog extends Animal{
 	}
 	public String getFur() {
 		return "shaggy";
+	}
+	
+	@Mutation
+	public static Dog getDog() {
+		return null;
 	}
 }


### PR DESCRIPTION
fix bug with generics where classes overlap. Need to generate namespaces
per generic

Animal<Cat> will make the entity name Animal_Cat

Not much new code mostly moved things around.

how it finds things is slightly different now, scans from method calls down.
No longer scans for @Entity just picks up Entities actually used as their definition can change due to generics.
