### PR TITLE
Restricted optional lists

### DIFF
--- a/src/main/java/com/fleetpin/graphql/builder/DirectivesSchema.java
+++ b/src/main/java/com/fleetpin/graphql/builder/DirectivesSchema.java
@@ -148,13 +148,18 @@ public class DirectivesSchema {
 			if(optional.isEmpty()) {
 				return CompletableFuture.completedFuture(response);
 			}
-			return restrict.allow(optional.get()).thenApply(allow -> {
-				if(allow == Boolean.TRUE) {
-					return response;
-				}else {
-					return Optional.empty();
-				}
-			});
+			var target = optional.get();
+			if(target instanceof List) {
+				return restrict.filter((List)target);
+			}else {
+				return restrict.allow(target).thenApply(allow -> {
+					if(allow == Boolean.TRUE) {
+						return response;
+					}else {
+						return Optional.empty();
+					}
+				});
+			}
 		}else {
 			return restrict.allow(response).thenApply(allow -> {
 				if(allow == Boolean.TRUE) {

--- a/src/main/java/com/fleetpin/graphql/builder/SchemaBuilder.java
+++ b/src/main/java/com/fleetpin/graphql/builder/SchemaBuilder.java
@@ -459,7 +459,7 @@ public class SchemaBuilder {
 			Restrict annotation = r.getAnnotation(Restrict.class);
 			var factoryClass = annotation.value();
 			var factory = factoryClass.getConstructor().newInstance();
-			if(!factory.extractType().isAssignableFrom(r)) {
+			if(!factory.extractType().equals(r)) {
 				throw new RuntimeException("Restrict annotation does match class applied to targets" + factory.extractType() + " but was on class " + r);
 			}
 			globalRestricts.add(factory);

--- a/src/main/java/com/fleetpin/graphql/builder/SchemaBuilder.java
+++ b/src/main/java/com/fleetpin/graphql/builder/SchemaBuilder.java
@@ -459,7 +459,7 @@ public class SchemaBuilder {
 			Restrict annotation = r.getAnnotation(Restrict.class);
 			var factoryClass = annotation.value();
 			var factory = factoryClass.getConstructor().newInstance();
-			if(!factory.extractType().equals(r)) {
+			if(!factory.extractType().isAssignableFrom(r)) {
 				throw new RuntimeException("Restrict annotation does match class applied to targets" + factory.extractType() + " but was on class " + r);
 			}
 			globalRestricts.add(factory);

--- a/src/test/java/com/fleetpin/graphql/builder/TypeGenericParsingTest.java
+++ b/src/test/java/com/fleetpin/graphql/builder/TypeGenericParsingTest.java
@@ -291,7 +291,6 @@ public class TypeGenericParsingTest {
 				"}" +
 				"}} ").getData();
 
-		System.out.println(response);
 		var makeCat = response.get("makeCat");
 		
 		var cat = makeCat.get("item");

--- a/src/test/java/com/fleetpin/graphql/builder/restrictions/EntityRestrictions.java
+++ b/src/test/java/com/fleetpin/graphql/builder/restrictions/EntityRestrictions.java
@@ -1,0 +1,25 @@
+package com.fleetpin.graphql.builder.restrictions;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.fleetpin.graphql.builder.RestrictType;
+import com.fleetpin.graphql.builder.RestrictTypeFactory;
+import com.fleetpin.graphql.builder.restrictions.parameter.RestrictedEntity;
+
+import graphql.schema.DataFetchingEnvironment;
+
+public class EntityRestrictions implements RestrictTypeFactory<RestrictedEntity> {
+
+	@Override
+	public CompletableFuture<RestrictType<RestrictedEntity>> create(DataFetchingEnvironment context) {
+		return CompletableFuture.completedFuture(new DatabaseRestrict());
+	}
+	
+	public static class DatabaseRestrict implements RestrictType<RestrictedEntity> {
+
+		@Override
+		public CompletableFuture<Boolean> allow(RestrictedEntity obj) {
+			return CompletableFuture.completedFuture(obj.isAllowed());
+		}
+	}
+}

--- a/src/test/java/com/fleetpin/graphql/builder/restrictions/RestrictionTypesTest.java
+++ b/src/test/java/com/fleetpin/graphql/builder/restrictions/RestrictionTypesTest.java
@@ -1,0 +1,112 @@
+package com.fleetpin.graphql.builder.restrictions;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fleetpin.graphql.builder.SchemaBuilder;
+
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+
+public class RestrictionTypesTest {
+	/*
+	 * Really basic tests, just to ensure restrictions work on different types.
+	 */
+	
+	private static GraphQL schema;
+	@BeforeAll
+	public static void init() throws ReflectiveOperationException {
+		schema = SchemaBuilder.build("com.fleetpin.graphql.builder.restrictions.parameter").build();	
+	}
+	
+	private static String singleQueryGql = "query entityQuery( $allowed: Boolean! ) { single(allowed: $allowed) { __typename } }";
+	private static String singleOptionalQueryGql = "query entityQuery( $allowed: Boolean ) { singleOptional(allowed: $allowed) { __typename } }";
+	private static String listQueryGql = "query entityQuery( $allowed: [Boolean!]! ) { list(allowed: $allowed) { __typename } }";
+	private static String listOptionalQueryGql = "query entityQuery( $allowed: [Boolean!] ) { listOptional(allowed: $allowed) { __typename } }";
+	
+	
+	@Test
+	public void singleEntityQuery() throws ReflectiveOperationException, JsonMappingException, JsonProcessingException {
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("allowed", true);
+		Map<String, Map<String,Object>> response = execute(singleQueryGql, variables).getData();
+		// No fancy checks. Just want to make ensure it executes without issue.
+		Assertions.assertTrue(response.get("single").containsKey("__typename"));
+	}
+	
+	@Test
+	public void singleOptionalEntityQuery() throws ReflectiveOperationException, JsonMappingException, JsonProcessingException {
+		Map<String, Object> variables = new HashMap<>();
+		
+		// Allowed
+		variables.put("allowed", true);
+		Map<String, Map<String,Object>> responseAllowed = execute(singleOptionalQueryGql, variables).getData();
+		Assertions.assertTrue(responseAllowed.get("singleOptional").containsKey("__typename"));
+		
+		// Not allowed
+		variables.put("allowed",  false);
+		Map<String, Object> responseDenied = execute(singleOptionalQueryGql, variables).getData();
+		Assertions.assertNull(responseDenied.get("singleOptional"));
+	}
+	
+	
+	@Test
+	public void listEntityQuery() throws ReflectiveOperationException, JsonMappingException, JsonProcessingException {
+		Map<String, Object> variables = new HashMap<>();
+		
+		variables.put("allowed", Arrays.asList(true,true,true));
+		Map<String, List<Object>> responseAllAllowed = execute(listQueryGql, variables).getData();
+		Assertions.assertEquals(3, responseAllAllowed.get("list").size());
+		
+		variables.put("allowed", Arrays.asList(true,false,true));
+		Map<String, List<Object>> responseSomeAllowed = execute(listQueryGql, variables).getData();
+		Assertions.assertEquals(2, responseSomeAllowed.get("list").size());
+		
+		variables.put("allowed", Arrays.asList(false,false,false));
+		Map<String, List<Object>> responseNoneAllowed = execute(listQueryGql, variables).getData();
+		Assertions.assertEquals(0, responseNoneAllowed.get("list").size());
+	}
+	
+	
+	@Test
+	public void optionalListEntityQuery() throws ReflectiveOperationException, JsonMappingException, JsonProcessingException {
+		Map<String, Object> variables = new HashMap<>();
+		
+		// No list passed through
+		Map<String, List<Object>> responseNoVariables = execute(listOptionalQueryGql, variables).getData();
+		Assertions.assertNull(responseNoVariables.get("listOptional"));
+		
+		variables.put("allowed", Arrays.asList(true,true,true));
+		Map<String, List<Object>> responseAllAllowed = execute(listOptionalQueryGql, variables).getData();
+		Assertions.assertEquals(3, responseAllAllowed.get("listOptional").size());
+		
+		variables.put("allowed", Arrays.asList(true,false,true));
+		Map<String, List<Object>> responseSomeAllowed = execute(listOptionalQueryGql, variables).getData();
+		Assertions.assertEquals(2, responseSomeAllowed.get("listOptional").size());
+		
+		variables.put("allowed", Arrays.asList(false,false,false));
+		Map<String, List<Object>> responseNoneAllowed = execute(listOptionalQueryGql, variables).getData();
+		Assertions.assertEquals(0, responseNoneAllowed.get("listOptional").size());
+	}
+	
+	private static ExecutionResult execute(String query, Map<String, Object> variables)
+			throws JsonMappingException, JsonProcessingException {
+		
+		var input = ExecutionInput.newExecutionInput().query(query).variables(variables).build();
+		ExecutionResult result = schema.execute(input);
+		if (!result.getErrors().isEmpty()) {
+			throw new RuntimeException(result.getErrors().toString());
+		}
+		return result;
+	}
+
+}

--- a/src/test/java/com/fleetpin/graphql/builder/restrictions/parameter/RestrictedEntity.java
+++ b/src/test/java/com/fleetpin/graphql/builder/restrictions/parameter/RestrictedEntity.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.fleetpin.graphql.builder.restrictions.parameter;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.fleetpin.graphql.builder.annotations.Entity;
+import com.fleetpin.graphql.builder.annotations.Query;
+import com.fleetpin.graphql.builder.annotations.Restrict;
+import com.fleetpin.graphql.builder.restrictions.EntityRestrictions;
+
+@Entity
+@Restrict(EntityRestrictions.class)
+public class RestrictedEntity {
+
+	private boolean allowed;
+
+	public boolean isAllowed() {
+		return allowed;
+	}
+
+	public void setAllowed(boolean allowed) {
+		this.allowed = allowed;
+	}
+
+	
+	@Query
+	public static RestrictedEntity single(Boolean allowed) {
+		RestrictedEntity entity = new RestrictedEntity();
+		entity.setAllowed(allowed);
+		return entity;
+	}
+	
+	@Query
+	public static Optional<RestrictedEntity> singleOptional(Optional<Boolean> allowed) {
+		if (allowed.isEmpty()) return Optional.empty();
+		RestrictedEntity entity = new RestrictedEntity();
+		entity.setAllowed(allowed.get());
+		return Optional.of(entity);
+	}
+	
+	@Query
+	public static List<RestrictedEntity> list(List<Boolean> allowed) {
+		return allowed.stream().map(isAllowed -> {
+			RestrictedEntity entity = new RestrictedEntity();
+			entity.setAllowed(isAllowed);
+			return entity; 
+		}).collect(Collectors.toList());
+	}
+	
+	@Query
+	public static Optional<List<RestrictedEntity>> listOptional(Optional<List<Boolean>> allowed) {
+		if (allowed.isEmpty()) return Optional.empty();
+		
+		return Optional.of(allowed.get().stream().map(isAllowed -> {
+			RestrictedEntity entity = new RestrictedEntity();
+			entity.setAllowed(isAllowed);
+			return entity;
+		}).collect(Collectors.toList()));
+	}
+	
+}


### PR DESCRIPTION
Allow returning of optional lists which have restrictions applied to objects in that list.

Currently returning an optional list which has restrictions on the object will result in an error.
Some basic tests included to ensure restrictions are correctly applied to the different types, including optional lists.